### PR TITLE
Fixes errors in charts without scales option (like pie)

### DIFF
--- a/src/plugin/hierarchical.js
+++ b/src/plugin/hierarchical.js
@@ -53,14 +53,27 @@ function generateCode(labels) {
 const HierarchicalPlugin = {
   id: 'chartJsPluginHierarchical',
 
+  _isValidScaleType(chart, scale) {
+    if (!chart.config.options.scales.hasOwnProperty(scale)) {
+      return false;
+    }
+    if (!Array.isArray(chart.config.options.scales[scale])) {
+      return false;
+    }
+    return chart.config.options.scales[scale][0].hasOwnProperty('type');
+  },
+
   /**
    * checks whether this plugin needs ot be enabled based on wehther one is a hierarchical axis
    */
   _enabled(chart) {
-    if (chart.config.options.scales.xAxes[0].type === 'hierarchical') {
+    if (!chart.config.options.hasOwnProperty('scales')) {
+      return null;
+    }
+    if (this._isValidScaleType(chart, 'xAxes') && chart.config.options.scales.xAxes[0].type === 'hierarchical') {
       return 'x';
     }
-    if (chart.config.options.scales.yAxes[0].type === 'hierarchical') {
+    if (this._isValidScaleType(chart, 'yAxes') && chart.config.options.scales.yAxes[0].type === 'hierarchical') {
       return 'y';
     }
     return null;


### PR DESCRIPTION
Fixes issue #13 

If you use a pie chart and the hierarchical scale plugin on the same page the pie chart will not draw.

This is caused by the `_enabled` function which checks if the `type` is set to `hierarchical` for the x or y scale. However if there is no scale configured the property will not be found and the script will fail.